### PR TITLE
FUZ Container support for Skyrim NX

### DIFF
--- a/src/VGAudio.Cli/CliArguments.cs
+++ b/src/VGAudio.Cli/CliArguments.cs
@@ -367,6 +367,9 @@ namespace VGAudio.Cli
                         case "-CBR":
                             options.EncodeCbr = true;
                             continue;
+                        case "-FUZ":
+                            options.SkyrimFuz = true;
+                            continue;
                     }
                 }
 

--- a/src/VGAudio.Cli/Options.cs
+++ b/src/VGAudio.Cli/Options.cs
@@ -43,6 +43,8 @@ namespace VGAudio.Cli
 
         public NxOpusHeaderType NxOpusHeaderType { get; set; } // Switch Opus
         public bool EncodeCbr { get; set; }
+
+        public bool SkyrimFuz { get; set; }
     }
 
     internal class JobFiles


### PR DESCRIPTION
Add an option to save a container as FUZ when using OPUS codec. Will look for a *.LIP file with same name in the input file location and embed it with the sound payload.